### PR TITLE
Rework the config system and rename the project to 'Lanoma'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rust:
 env:
   global:
     - RUST_BACKTRACE: full
-    - PROJECT_NAME: texture-notes
+    - PROJECT_NAME: lanoma
 cache: cargo
 
 # For now, it only support the operating systems I always get to use. 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -38,6 +38,9 @@ It is created with an https://asciidoctor.org/[Asciidoctor] document.
 
 * Rewrite the application with the https://www.rust-lang.org/[Rust] language. 
 
+* Changed the application name to Lanoma. 
+It just there to make it easier to remember (and type). 
+
 * Restructure the application with its own library crate. 
 Making it possible to create other binaries with the same application logic. 
 
@@ -52,7 +55,10 @@ From this point, the binder is now referred to as the **shelf** or the **base di
 ** A shelf is still composed of **subjects** (terminology may change in the future). 
 Each subject can have a specific metadata file. 
 ** Remove the database entirely. 
-Now, the binder system is entirely dependent of the filesystem. 
+Now, the shelf system is entirely dependent of the filesystem. 
+It is merely a path prefix for the subjects now. 
+
+* Subjects can now be referred to similarly to paths. 
 
 * Revise the profile system. 
 ** The common files folder has been removed. 
@@ -65,10 +71,11 @@ This allows for more flexibility and intuition in interacting with the program.
 
 * Templates support from https://docs.python.org/3/library/string.html#custom-string-formatting[Python template strings] to https://github.com/sunng87/handlebars-rust[Handlebars Rust implementation]. 
 ** The templates are also `.hbs` files in the templates folder. 
+** It also comes with a set of helper functions similar to https://gohugo.io/templates/introduction/[Hugo templates]. 
 
 * Restructure the profile directory structure for neater custom configurations and easier organization. 
 ** The default profile location is stored with the respective config folder of the OS. 
-This allows Texture Notes to be simpler and modular. 
+This allows Lanoma to be simpler and modular. 
 Although, this sacrifices the multiple user aspect (though that's not needed at this point). 
 ** The profile metadata filename has been changed to `.profile.toml`. 
 ** Templates has been moved to its own folder at `.templates/`. 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "texture-notes-cli"
+name = "lanoma"
 version = "0.1.0"
 authors = ["foo-dogsquared <foo.dogsquared@gmail.com>"]
 edition = "2018"
@@ -15,7 +15,7 @@ members = [
 directories = "2.0.2"
 rayon = "1.3.0"
 structopt = "0.3"
-texture-notes-lib = {path = "lib"}
+lanoma-lib = {path = "lib"}
 toml = "0.5.5"
 
 [profile.release]
@@ -24,5 +24,5 @@ lto = true
 panic = "abort"
 
 [[bin]]
-name = "texture-notes"
+name = "lanoma"
 path = "src/main.rs"

--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
-= Texture Notes 
+= Lanoma 
 :toc:
 
-A lecture notes manager that aims for self-studying and university classes footnote:[Mainly, the author of this program, https://github.com/foo-dogsquared[@foo-dogsquared].]. 
+A basic LaTeX notes manager that aims for self-studying and university classes footnote:[Mainly, the author of this program, https://github.com/foo-dogsquared[@foo-dogsquared].]. 
 It is mainly composed of a command line program where you can easily manage your LaTeX notes. 
 
 For now, the notes manager is specifically created for my specific workflow so no there's not much room for general use-cases. 
@@ -70,7 +70,7 @@ I've also met people online that are more content with a simple list of director
 
 == Installation 
 
-You can simply download the https://github.com/foo-dogsquared/texture-notes-v2/releases[provided binaries in the releases page]. 
+You can simply download the https://github.com/foo-dogsquared/lanoma/releases[provided binaries in the releases page]. 
 If you're using https://doc.rust-lang.org/cargo/[Cargo], you can install the binary with https://doc.rust-lang.org/cargo/commands/cargo-install.html?highlight=install#cargo-install[`cargo install` command]. 
 
 If there's no available version for your operating system of choice, you can compile one yourself. 
@@ -79,7 +79,7 @@ First, make sure you have the Rust toolchain (>=`v1.39.0` just to be safe) and t
 Then clone the Git repository into your machine and build the executable with `cargo build --release`. 
 footnote:[You can also build with `make` by using the `build` rule (i.e., `make build`).]
 
-Wait for the compilation and get the binary (named as `texture-notes`) in the `target/release/` folder. 
+Wait for the compilation and get the binary (named as `lanoma`) in the `target/release/` folder. 
 You can then move the binary in your `$PATH`. 
 
 
@@ -98,18 +98,18 @@ That's pretty much it.
 
 === Quick start 
 
-To get started with Texture Notes, you need a profile. 
+To get started with Lanoma, you need a profile. 
 
 You can simply create a profile with the `init` command. 
 
 [source, shell]
 ----
 # Initialize the profile in the respective config folder of your operating system 
-texture-notes-v2 init
+lanoma init
 
 # Initialize the profile in other directories if you don't want to. 
 # Though, you have to specify the profile at every command. 
-texture-notes-v2 init --profile "~/Documents"
+lanoma init --profile "~/Documents"
 ----
 
 Once you have initialized a profile, you can now create subjects and notes. 
@@ -118,17 +118,17 @@ Though in order to add notes, you need to create subjects/folders first.
 [source, shell]
 ----
 # Add some subjects 
-texture-notes-v2 add subjects "Mathematics" "Science"
+lanoma add subjects "Mathematics" "Science"
 
 # After adding some subjects, you can add some notes 
-texture-notes-v2 add notes "Mathematics" "Introduction to Calculus" 
+lanoma add notes "Mathematics" "Introduction to Calculus" 
 
 # To compile all notes under "Mathematics" 
-texture-notes-v2 compile subjects "Mathematics"
+lanoma compile subjects "Mathematics"
 ----
 
 You can check out more options in the link:docs/manual.adoc[manual]. 
-It also gives the complete details of what you need to know with Texture Notes. 
+It also gives the complete details of what you need to know with Lanoma. 
 
 
 
@@ -168,7 +168,7 @@ The project uses https://github.com/rust-lang/cargo[Cargo] for managing the proj
 * To run the binary of the project, execute `cargo run` in the shell. 
 To add command line arguments, just append two dashes (`--`) after the run command. 
 
-* To run the tests of the library crate, call `cargo test --package texture-notes-lib --lib`. 
+* To run the tests of the library crate, call `cargo test --package lanoma-lib --lib`. 
 
 * Using the https://github.com/rust-lang/rls[RLS] plugin of your text editor of choice is recommended. 
 If you're using https://code.visualstudio.com/[Visual Studio Code], it is fully recommended to have it installed. 

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,8 @@
 = Lanoma 
 :toc:
 
+:program: Lanoma
+
 A basic LaTeX notes manager that aims for self-studying and university classes footnote:[Mainly, the author of this program, https://github.com/foo-dogsquared[@foo-dogsquared].]. 
 It is mainly composed of a command line program where you can easily manage your LaTeX notes. 
 
@@ -30,24 +32,20 @@ Nonetheless, pull requests for improvements are always welcome!
 
 
 
-== Limitations
+== Limitations and non-goals 
 
-Now the design rationale is out, let's explicitly lay out the expected limitations of this program. 
+Now the design rationale is out, let's explicitly lay out the expected limitations and non-goals from the time of creating this project. 
 
 * First and foremost, it's a niche tool for a **very** niche use. 
 Also, with the use of makefiles and shell scripts, you can easily set up a similar (or better) workflow for your LaTeX documents. 
 Besides, creating a similar tool could've been easier (and better) with shell scripts and makefiles. 
 I just did to myself because I want to learn Rust. 
+{program} does have some level of customizability but it is limited. 
 
-* There's not much room for customizability. 
-It is based from my specific workflow, after all. 
-It is ought to happen. 
-Maybe in the future, I'll improve to be used in general cases but I doubt it will improve the program. 
+* This is not made for general use cases. 
+Though, it is considered especially with the upcoming improvements of the underlying libraries (like creating dynamic helpers with Rhai [from https://github.com/sunng87/handlebars-rust/issues/301]). 
 
 * This is not made for organizing the notes or anything. 
-
-* It uses LaTeX. ;) 
-footnote:[I would like to create a generic personal knowledge base for Asciidoctor documents or even better, a configurable personal knowledge base similar to https://gohugo.io/content-management/archetypes/[Hugo archetypes] and https://gohugo.io/content-management/formats/#additional-formats-through-external-helpers[the external helpers system].] 
 
 If you're looking for an alternative for your personal knowledge base, a simple directory tree of notes will do. 
 I've also made my personal knowledge base with just a folder of https://asciidoctor.org/[Asciidoctor] documents and created a Python script for compiling them all. 
@@ -98,7 +96,7 @@ That's pretty much it.
 
 === Quick start 
 
-To get started with Lanoma, you need a profile. 
+To get started with {program}, you need a profile. 
 
 You can simply create a profile with the `init` command. 
 
@@ -128,7 +126,7 @@ lanoma compile subjects "Mathematics"
 ----
 
 You can check out more options in the link:docs/manual.adoc[manual]. 
-It also gives the complete details of what you need to know with Lanoma. 
+It also gives the complete details of what you need to know with {program}. 
 
 
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -9,8 +9,8 @@ package_executable() {
     mkdir -p "$staging"
     mkdir -p "$staging/docs"
     cp {README.adoc,LICENSE} "$staging"
-    cp {docs/manual.adoc,CHANGELOG.adoc,texture-notes.1} "$staging/docs"
-    cp "target/$TARGET/release/texture-notes" "$staging"
+    cp {docs/manual.adoc,CHANGELOG.adoc,lanoma.1} "$staging/docs"
+    cp "target/$TARGET/release/lanoma" "$staging"
 
     # This directory is where the binaries will be stored.
     local out_dir="$(pwd)/deployment"

--- a/docs/manual.adoc
+++ b/docs/manual.adoc
@@ -1,13 +1,14 @@
-= texture-notes(1)
+= lanoma(1)
 Gabriel Arazas
 2019-12-31
 :toc:
 :doctype: manpage
-:program: Texture Notes
+:program: Lanoma
 :manmanual: {program} Manual
-:mansource: {program} v2.0.0
+:mansource: {program} v0.1.0
 :man-linkstyle: pass:[red R < >]
 
+:binary-name: lanoma
 :default-template-name: _default
 :templates-folder: .templates
 :template-file-ext: hbs
@@ -21,14 +22,14 @@ Gabriel Arazas
 
 == Name 
 
-texture-notes - a note manager for LaTeX documents; inspired from Gilles Castel's LaTeX note management workflow post (https://castel.dev/post/lecture-notes-3/)
+{binary-name} - a basic note manager for LaTeX documents; inspired from Gilles Castel's LaTeX note management workflow post (https://castel.dev/post/lecture-notes-3/)
 
 
 
 
 == Sypnosis 
 
-*texture-notes* [_GLOBAL OPTIONS_] [_SUBCOMMAND_]... [_SUBCOMMAND OPTIONS_] [_SUBCOMMAND ARGUMENT(S)_]...
+*{binary-name}* [_GLOBAL OPTIONS_] [_SUBCOMMAND_]... [_SUBCOMMAND OPTIONS_] [_SUBCOMMAND ARGUMENT(S)_]...
 
 
 
@@ -74,12 +75,12 @@ Print the help section of the subcommand or the application.
 
 === Initializing and customizing a profile 
 
-To get started with Texture Notes, one will have to initialize a profile. 
+To get started with {program}, one will have to initialize a profile. 
 To initialize a profile, just run the `init` subcommand. 
 
 [source, shell]
 ----
-texture-notes init
+lanoma init
 ----
 
 This initializes a profile at the default config folder of the operating system. 
@@ -92,28 +93,28 @@ The TOML file should have the keys `name` and `version` along with the correct d
 Custom keys can be added which is useful when creating note templates which will be discussed later in the manual. 
 
 * A set of templates in `{templates-folder}` directory. 
-It is a key-value store with the name of the `.tex` files as the key. 
+It is a key-value store with the name of the `.{template-file-ext}` files as the key. 
 
 
-=== Using Texture Notes 
+=== Using {program} 
 
 Now a profile is available, you can now create some subjects and notes in a directory referred to as the *base directory* or the *shelf*. 
 
 You can view the available subcommands at the <<Subcommands>> section. 
 Most of the subcommands for interacting with the shelf requires an inner subcommand indicating whether it's a subject or a note. 
 
-Here are some of the examples when using Texture Notes. 
+Here are some of the examples when using {program}. 
 
 [source, shell]
 ----
-texture-notes add subjects "Calculus I" "Calculus II"
+lanoma add subjects "Calculus I" "Calculus II"
 
-texture-notes compile notes "Calculus I" -- "Introduction to limits" "Taylor series"
+lanoma compile notes "Calculus I" -- "Introduction to limits" "Taylor series"
 
-texture-notes remove subjects "Calculus II"
+lanoma remove subjects "Calculus II"
 ----
 
-A *subject* in Texture Note is just a folder with a metadata file named `{subject-metadata-file}`. 
+A *subject* in {program} is just a folder with a metadata file named `{subject-metadata-file}`. 
 
 For convenience, you can refer to the same subject as long as the resulting kebab-case string is the same. 
 
@@ -138,9 +139,9 @@ You can refer to the Calculus I from the first year folder in different ways ass
 
 [source, shell]
 ----
-texture-notes add notes "Year 1/Semester 1/Calculus I" -- NOTES...
-texture-notes add notes "year-1/semester-1/calculus-i" -- NOTES...
-texture-notes add notes "year-1/semester-1/Calculus I" -- NOTES...
+lanoma add notes "Year 1/Semester 1/Calculus I" -- NOTES...
+lanoma add notes "year-1/semester-1/calculus-i" -- NOTES...
+lanoma add notes "year-1/semester-1/Calculus I" -- NOTES...
 ----
 
 As long as the resulting kebab-case of each component in the path is the same with the folder, it is considered as the same subject in the filesystem. 
@@ -150,19 +151,19 @@ For certain cases, this can be distinct when creating notes or the subject.
 The same applies for referring to notes. 
 As long as the resulting kebab-case is the same, it refers to the same note in the filesystem. 
 
-That said, with this implementation, Texture Notes will not recognize notes (and subjects) in the filesystem that are not in valid kebab-case. 
+That said, with this implementation, {program} will not recognize notes (and subjects) in the filesystem that are not in valid kebab-case. 
 You can exploit this to make certain notes and subjects hidden simply by adding and renaming the file with an invalid kebab-case character (e.g., an underscore (`_`), an exclamation point (`!`), dot (`.`)). 
 
 
 === Note templates 
 
-Texture Notes has a simple templating system for your LaTeX documents. 
+{program} has a simple templating system for your LaTeX documents. 
 As briefly mentioned, the templates are located in a profile specifically in the `{templates-folder}` folder. 
 
 Internally, the templates is represented as a key-value store. 
 The key-value store comes from the folder that expects a list of `.{template-file-ext}` files with the file name as the key. 
 
-Texture Notes use https://crates.io/crates/handlebars[a Rust implementation of Handlebars] as the templating language. 
+{program} use https://crates.io/crates/handlebars[a Rust implementation of Handlebars] as the templating language. 
 It is definitely important to make sure the templates is valid. 
 
 The template store primarily use the `{default-template-name}` template as the default key. 
@@ -185,13 +186,12 @@ Sample content.
 ----
 
 To override the default template, just create `{default-template-name}.{template-file-ext}` on the templates folder. 
-The Handlebars configuration within the Texture Notes also comes with a few helper functions for convenience. 
+The Handlebars configuration within the {program} also comes with a few helper functions for convenience. 
 Check out the <<Templating>> section in the appendix for more details. 
 
-As previously said, Texture Notes uses a templating engine specifically https://crates.io/crates/handlebars/3.0.0-beta.5[a Rust implementation] of https://handlebarsjs.com/[Handlebars]. 
-To set dynamic values, a Handlebars expression delimited by two pairs of curly braces (`{{$EXPR}}`). 
-Practically in using Texture Notes, these are often used to refer to a https://github.com/toml-lang/toml[TOML] value. 
+As previously said, {program} uses a templating engine specifically https://crates.io/crates/handlebars/3.0.0-beta.5[a Rust implementation] of https://handlebarsjs.com/[Handlebars]. 
 
+Practically in templating with Handlebars and {program}, these are often used to refer to a https://github.com/toml-lang/toml[TOML] value. 
 When creating a note, a TOML table is forming from different sources such as the profile and subject metadata. 
 
 For example, let's create a note titled "Introduction to limits" under the subject "Calculus I". 
@@ -199,7 +199,7 @@ Assuming the shelf is the current directory, the shell command would look like t
 
 [source, shell]
 ----
-texture-notes add notes "Calculus I" -- "Introduction to limits"
+lanoma add notes "Calculus I" -- "Introduction to limits"
 ----
 
 The following TOML table is then formed in the note creation process. 
@@ -236,13 +236,13 @@ It is accessible under the `subject` table.
 
 === LaTeX documents compilation 
 
-Texture Notes can do basic automation of compiling LaTeX documents in parallel through threads. 
+{program} can do basic automation of compiling LaTeX documents in parallel through threads. 
 
 This is mainly used with the `compile` subcommand. 
 
 [source, shell]
 ----
-texture-notes compile notes "Calculus I" -- "Introduction to limits"
+lanoma compile notes "Calculus I" -- "Introduction to limits"
 ----
 
 You can change the number of threads compiling the documents with the `--thread-count` option. 
@@ -264,7 +264,7 @@ Even if there is a `_files` key, the command line option will override the note 
 
 === Master notes 
 
-Texture Notes also allows to create *master notes*. 
+{program} also allows to create *master notes*. 
 
 A master note is a note combined from the filtered notes of a subject. 
 It is associated with one and only one subject. 
@@ -274,7 +274,7 @@ To generate a master note, run the *master* subcommand.
 
 [source, shell]
 ----
-texture-notes master "Calculus I"
+lanoma master "Calculus I"
 ----
 
 By default, the master note template is `{master-default-template}`. 
@@ -323,10 +323,10 @@ General errors — e.g., invalid or nonexistent profile, TOML or Handlebars pars
 == Repository 
 
 Git repository::
-https://github.com/foo-dogsquared/texture-notes-v2
+https://github.com/foo-dogsquared/lanoma
 
 Issue tracker::
-https://github.com/foo-dogsquared/texture-notes-v2/issues
+https://github.com/foo-dogsquared/lanoma/issues
 
 
 
@@ -334,7 +334,7 @@ https://github.com/foo-dogsquared/texture-notes-v2/issues
 [appendix]
 == Config reference 
 
-A reference of the keys Texture Notes officially recognizes. 
+A reference of the keys {program} officially recognizes. 
 
 *`{profile-metadata-file}`*:: 
 
@@ -364,7 +364,7 @@ If this key is absent in the file, it uses `latexmk -pdf {{note}}`.
 [appendix]
 == Built-in object data 
 
-Most component (i.e., subjects, notes) in Texture Notes has a resulting object data associated with it. 
+Most component (i.e., subjects, notes) in {program} has a resulting object data associated with it. 
 This is mostly used for creating notes (and master notes). 
 
 
@@ -473,11 +473,11 @@ The resulting TOML when creating the master note is similar to the resulting TOM
 
 By default, the profile location uses the config folder of the operating system. 
 
-* For Linux, the config folder is at `$XDG_CONFIG_HOME/texture-notes` or at `$HOME/.config/texture-notes`. 
-* For Windows, the configuration is stored at `%APPDATA%/texture-notes`. 
-* For MacOS, it is at `$HOME/Library/Preferences/texture-notes`. 
+* For Linux, the config folder is at `$XDG_CONFIG_HOME/lanoma` or at `$HOME/.config/lanoma`. 
+* For Windows, the configuration is stored at `%APPDATA%/lanoma`. 
+* For MacOS, it is at `$HOME/Library/Preferences/lanoma`. 
 
-Specifically, Texture Notes utilizes the https://crates.io/crates/directories[`directories` crate from crates.io]. 
+Specifically, {program} utilizes the https://crates.io/crates/directories[`directories` crate from crates.io]. 
 You can refer to the crates.io page for more details. 
 
 

--- a/docs/manual.adoc
+++ b/docs/manual.adoc
@@ -294,7 +294,7 @@ For future references, the default master template has the following content.
 % Frontmatter of the class note
 
 {{#each master.notes}}
-Note: {{this.name}} {{this.path_in_shelf}}
+Note: {{this.title}}
 {{/each }}
 
 \end{document}

--- a/docs/manual.adoc
+++ b/docs/manual.adoc
@@ -22,7 +22,7 @@ Gabriel Arazas
 
 == Name 
 
-{binary-name} - a basic note manager for LaTeX documents; inspired from Gilles Castel's LaTeX note management workflow post (https://castel.dev/post/lecture-notes-3/)
+{binary-name} - a glorified basic note manager for LaTeX documents that could've been easily created with shell scripts; inspired from Gilles Castel's LaTeX note management workflow post (https://castel.dev/post/lecture-notes-3/)
 
 
 
@@ -54,6 +54,7 @@ Initialize a profile.
 
 *add*::
 Add a subject or a note. 
+footnote:[If you're creating notes, I recommend to use https://github.com/foo-dogsquared/hantemcli[hantemcli] which is another project of mine to easily render Handlebars templates in the command line. It could also create templates with data formats other than TOML.]
 
 *remove*::
 Remove a subject or a note. 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -11,7 +11,7 @@ cargo-features = ["named-profiles"]
 chrono = { version = "0.4.10", features = ["serde"] }
 lazy_static = "1.4.0"
 globwalk = "0.7.1"
-handlebars = "2.0.2"
+handlebars = "3"
 heck = "0.3.1"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5.5"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "texture-notes-lib"
+name = "lanoma-lib"
 version = "2.0.0"
 authors = ["foo-dogsquared <foo.dogsquared@gmail.com>"]
 edition = "2018"

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -87,9 +87,6 @@ pub struct ProfileConfig {
     #[serde(default = "default_version")]
     version: String,
 
-    #[serde(default)]
-    subject: SubjectConfig,
-
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
 }
@@ -97,7 +94,6 @@ pub struct ProfileConfig {
 impl Default for ProfileConfig {
     fn default() -> Self {
         Self {
-            subject: SubjectConfig::default(),
             name: default_name(),
             version: default_version(),
             extra: HashMap::new(),

--- a/lib/src/config.rs
+++ b/lib/src/config.rs
@@ -10,7 +10,7 @@ use crate::consts;
 use crate::error::Error;
 
 const DEFAULT_FILES: &str = "*.tex";
-const DEFAULT_CMD: &str = "pdflatex {{note}}";
+const DEFAULT_CMD: &str = "latexmk -pdf {{note}}";
 const DEFAULT_NAME: &str = "New Student";
 
 /// The configuration of a subject.

--- a/lib/src/consts.rs
+++ b/lib/src/consts.rs
@@ -12,7 +12,7 @@ pub const MASTER_NOTE_TEMPLATE: &'static str = r"\documentclass[class=memoir, cr
 % Frontmatter of the class note
 
 {{#each master.notes}}
-Note: {{this.name}} {{this.path_in_shelf}}
+Note: {{this.title}}
 {{/each }}
 
 \end{document}

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -49,6 +49,9 @@ pub enum Error {
 
     /// Given when the glob pattern is not recognizable.
     GlobParsingError(globwalk::GlobError),
+
+    /// A collection of error used for more efficient error reporting.
+    Errors(Vec<Error>),
 }
 
 impl error::Error for Error {}
@@ -86,16 +89,17 @@ impl fmt::Display for Error {
             Error::MissingDataError(ref p) => write!(f, "{} is missing.", p),
             Error::TomlValueError(ref p) => write!(f, "{} is invalid.", p),
             Error::TomlSerializeError(ref p) => write!(f, "{}", p),
-            Error::HandlebarsTemplateError(ref p) => write!(f, "{} is an invalid template.", p),
-            Error::HandlebarsTemplateFileError(ref p) => write!(
-                f,
-                "Handlebars with the instance '{}' has an error occurred.",
-                p
-            ),
-            Error::HandlebarsRenderError(ref p) => {
-                write!(f, "{}: Error occurred while rendering.", p)
-            }
+            Error::HandlebarsTemplateError(ref p) => write!(f, "{}", p),
+            Error::HandlebarsTemplateFileError(ref p) => write!(f, "{}", p),
+            Error::HandlebarsRenderError(ref p) => write!(f, "{}", p),
             Error::GlobParsingError(ref error) => error.fmt(f),
+            Error::Errors(ref errors) => {
+                for error in errors {
+                    writeln!(f, "{}", error)?;
+                }
+
+                Ok(())
+            }
         }
     }
 }

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -8,7 +8,7 @@ use globwalk;
 use handlebars;
 use toml;
 
-/// An enum for errors possible to happen in the Texture Notes library.
+/// An enum for errors possible to happen in the Lanoma library.
 #[derive(Debug)]
 pub enum Error {
     /// Error when the value is invalid in a function.

--- a/lib/src/helpers/fs.rs
+++ b/lib/src/helpers/fs.rs
@@ -233,24 +233,24 @@ mod tests {
 
     #[test]
     fn relpath_to_common_relpaths() {
-        let base = PathBuf::from("./tests/texture-notes-profile/notes/calculus");
-        let dst = PathBuf::from("./tests/texture-notes-profile/common");
+        let base = PathBuf::from("./tests/lanoma-profile/notes/calculus");
+        let dst = PathBuf::from("./tests/lanoma-profile/common");
 
         assert_eq!(relative_path_from(dst, base), Some("../../common".into()));
     }
 
     #[test]
     fn relpath_to_leading_common_relpaths() {
-        let base = PathBuf::from("./tests/texture-notes-profile/common");
-        let dst = PathBuf::from("./tests/texture-notes-profile/common/calculus");
+        let base = PathBuf::from("./tests/lanoma-profile/common");
+        let dst = PathBuf::from("./tests/lanoma-profile/common/calculus");
 
         assert_eq!(relative_path_from(dst, base), Some("calculus".into()));
     }
 
     #[test]
     fn relpath_to_the_same_input() {
-        let base = PathBuf::from("./tests/texture-notes-profile/common");
-        let dst = PathBuf::from("./tests/texture-notes-profile/common");
+        let base = PathBuf::from("./tests/lanoma-profile/common");
+        let dst = PathBuf::from("./tests/lanoma-profile/common");
 
         assert_eq!(relative_path_from(dst, base), Some("".into()));
     }
@@ -291,7 +291,7 @@ mod tests {
     #[test]
     fn relpath_from_root_to_current_dir() {
         let base = PathBuf::from("/dev/sda/calculus-drive");
-        let dst = PathBuf::from("./tests/texture-notes-profile/common");
+        let dst = PathBuf::from("./tests/lanoma-profile/common");
 
         assert_eq!(relative_path_from(dst, base), None);
     }
@@ -309,11 +309,11 @@ mod tests {
     #[test]
     fn relpath_to_common_root() {
         let base = PathBuf::from("C:\\dev\\sda\\calculus-drive");
-        let dst = PathBuf::from("C:\\tests\\texture-notes-profile\\common");
+        let dst = PathBuf::from("C:\\tests\\lanoma-profile\\common");
 
         assert_eq!(
             relative_path_from(dst.clone(), base),
-            Some("../../../tests/texture-notes-profile/common".into())
+            Some("../../../tests/lanoma-profile/common".into())
         );
     }
 
@@ -321,21 +321,21 @@ mod tests {
     #[test]
     fn relpath_to_common_root() {
         let base = PathBuf::from("/dev/sda/calculus-drive");
-        let dst = PathBuf::from("/tests/texture-notes-profile/common");
+        let dst = PathBuf::from("/tests/lanoma-profile/common");
 
         assert_eq!(
             relative_path_from(dst, base),
-            Some("../../../tests/texture-notes-profile/common".into())
+            Some("../../../tests/lanoma-profile/common".into())
         );
     }
 
     #[test]
     fn leading_current_dir_naive_normalized() {
-        let test_case = PathBuf::from("./tests/texture-notes-profile/notes/calculus");
+        let test_case = PathBuf::from("./tests/lanoma-profile/notes/calculus");
 
         assert_eq!(
             naively_normalize_path(test_case),
-            Some("tests/texture-notes-profile/notes/calculus".into())
+            Some("tests/lanoma-profile/notes/calculus".into())
         );
     }
 

--- a/lib/src/helpers/fs.rs
+++ b/lib/src/helpers/fs.rs
@@ -193,32 +193,6 @@ pub fn naively_normalize_path<P: AsRef<Path>>(path: P) -> Option<PathBuf> {
     }
 }
 
-/// A generic function for writing a shelf item (as a file).
-pub fn write_file<P, S>(
-    path: P,
-    string: S,
-    strict: bool,
-) -> Result<(), Error>
-where
-    P: AsRef<Path>,
-    S: AsRef<str>,
-{
-    let path = path.as_ref();
-    let mut file_open_options = OpenOptions::new();
-    file_open_options.write(true).create(true);
-
-    if strict {
-        file_open_options.create_new(true);
-    } else {
-        file_open_options.truncate(true);
-    }
-
-    let mut file = file_open_options.open(path).map_err(Error::IoError)?;
-    file.write(string.as_ref().as_bytes())
-        .map_err(Error::IoError)?;
-    Ok(())
-}
-
 fn is_parent_dir(component: Component) -> bool {
     match component {
         Component::ParentDir => true,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -26,7 +26,7 @@ pub type Result<T> = result::Result<T, Error>;
 // Making it static since it does not handle any templates anyway and only here for rendering the string.
 lazy_static! {
     /// A static Handlebars registry.
-    pub static ref HANDLEBARS_REG: handlebars::Handlebars = handlebars::Handlebars::new();
+    pub static ref HANDLEBARS_REG: handlebars::Handlebars<'static> = handlebars::Handlebars::new();
 }
 
 /// A trait that specifies an object has a set of associated data.

--- a/lib/src/masternote.rs
+++ b/lib/src/masternote.rs
@@ -11,7 +11,6 @@ use crate::subjects::Subject;
 use crate::Object;
 use crate::Result;
 
-#[macro_use]
 use crate::modify_toml_table;
 
 const MASTER_NOTE_FILE: &str = "_master.tex";

--- a/lib/src/note.rs
+++ b/lib/src/note.rs
@@ -13,7 +13,6 @@ use crate::shelf::{Shelf, ShelfData, ShelfItem};
 use crate::subjects::Subject;
 use crate::{Object, Result};
 
-#[macro_use]
 use crate::modify_toml_table;
 
 /// The individual LaTeX documents in a notes instance.

--- a/lib/src/profile.rs
+++ b/lib/src/profile.rs
@@ -152,9 +152,12 @@ impl Profile {
 
         let mut profile = Self::new();
 
-        profile.path = fs::canonicalize(path).map_err(Error::IoError)?;
+        profile.path = match fs::canonicalize(path.clone()) {
+            Ok(v) => v,
+            Err(_e) => return Err(Error::InvalidProfileError(path)),
+        };
         if !profile.has_templates() {
-            return Err(Error::InvalidProfileError(profile.path.clone()));
+            return Err(Error::InvalidProfileError(profile.path));
         }
 
         profile.init_templates()?;

--- a/lib/src/profile.rs
+++ b/lib/src/profile.rs
@@ -1,4 +1,4 @@
-//! A profile is an object that holds all of the required information for the operations in Texture Notes.
+//! A profile is an object that holds all of the required information for the operations in Lanoma.
 //! For now, a profile contains the metadata and the templates.
 //!
 //! On the filesystem, it is represented as a folder with specific files and folders.
@@ -305,27 +305,11 @@ impl Profile {
 
         Ok(())
     }
-
-    /// Returns the command for compiling the notes.
-    /// By default, the compilation command is `latexmk -pdf`.
-    ///
-    /// If there's no valid value found from the key (i.e., invalid type), it will return the default command.
-    pub fn compile_note_command(&self) -> String {
-        let PROFILE_DEFAULT_COMMAND = String::from("latexmk -pdf {{note}}");
-        match self.config.extra.get("command").as_ref() {
-            Some(value) => match value.is_str() {
-                true => value.as_str().unwrap().to_string(),
-                false => PROFILE_DEFAULT_COMMAND,
-            },
-            None => PROFILE_DEFAULT_COMMAND,
-        }
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::helpers;
     use crate::note::Note;
     use crate::shelf::{Shelf, ShelfItem};
     use crate::subjects::Subject;

--- a/lib/src/shelf.rs
+++ b/lib/src/shelf.rs
@@ -7,7 +7,6 @@ use crate::helpers;
 use crate::Object;
 use crate::Result;
 
-#[macro_use]
 use crate::modify_toml_table;
 
 /// A struct holding the common export options.

--- a/lib/src/shelf.rs
+++ b/lib/src/shelf.rs
@@ -39,7 +39,7 @@ impl ExportOptions {
 }
 
 /// The shelf is where it contains the subjects and its notes.
-/// In other words, it is the base directory of the operations taken place in Texture Notes.
+/// In other words, it is the base directory of the operations taken place in Lanoma.
 #[derive(Debug, Clone)]
 pub struct Shelf {
     path: PathBuf,

--- a/lib/src/subjects.rs
+++ b/lib/src/subjects.rs
@@ -16,7 +16,6 @@ use crate::note::Note;
 use crate::shelf::{Shelf, ShelfData, ShelfItem};
 use crate::{Object, Result};
 
-#[macro_use]
 use crate::{modify_toml_table, upsert_toml_table};
 
 const SUBJECT_METADATA_FILE: &str = "info.toml";

--- a/lib/src/subjects.rs
+++ b/lib/src/subjects.rs
@@ -127,7 +127,7 @@ impl Subject {
     /// # Example
     ///
     /// ```
-    /// use texture_notes_lib::subjects::Subject;
+    /// use lanoma_lib::subjects::Subject;
     ///
     /// assert_eq!(Subject::new("Mathematics").name(), Subject::new("Mathematics/Calculus/..").name())
     /// ```
@@ -290,7 +290,7 @@ impl Subject {
     /// # Example
     ///
     /// ```
-    /// use texture_notes_lib::subjects::Subject;
+    /// use lanoma_lib::subjects::Subject;
     ///
     /// let subject = Subject::new("Bachelor I/Semester I/Calculus");
     ///

--- a/lib/src/templates.rs
+++ b/lib/src/templates.rs
@@ -141,13 +141,12 @@ impl<'a> TemplateHandlebarsRegistry<'a> {
         let mut registered_templates = vec![];
         let mut template_errors = vec![];
         for template in templates.iter() {
-
             match self
                 .0
                 .register_template_string(&template.name, &template.s)
                 .map_err(Error::HandlebarsTemplateError)
             {
-                Ok(_v) => registered_templates.push(template), 
+                Ok(_v) => registered_templates.push(template),
                 Err(e) => template_errors.push(e),
             }
         }

--- a/lib/src/templates.rs
+++ b/lib/src/templates.rs
@@ -13,7 +13,6 @@ use serde;
 
 use crate::error::Error;
 use crate::helpers;
-use crate::Result;
 
 /// A trait for the template registry.
 /// It handles all of the template operations such as checking if the there is already a template
@@ -23,12 +22,12 @@ pub trait TemplateRegistry {
     fn register(
         &mut self,
         template: &Template,
-    ) -> Result<()>;
+    ) -> Result<(), Error>;
 
     fn unregister<S>(
         &mut self,
         template_name: S,
-    ) -> Result<()>
+    ) -> Result<(), Error>
     where
         S: AsRef<str>;
 
@@ -46,22 +45,23 @@ pub trait TemplateRegistry {
         &self,
         name: S,
         value: V,
-    ) -> Result<String>
+    ) -> Result<String, Error>
     where
         S: AsRef<str>,
         V: serde::Serialize;
 }
 
 /// The template registry implemented with the `rust-handlebars` crate.
-pub struct TemplateHandlebarsRegistry(handlebars::Handlebars);
+#[derive(Debug)]
+pub struct TemplateHandlebarsRegistry<'a>(handlebars::Handlebars<'a>);
 
-impl TemplateRegistry for TemplateHandlebarsRegistry {
+impl<'a> TemplateRegistry for TemplateHandlebarsRegistry<'a> {
     /// Registers a template in the registry.
     /// If there is a template with the same name, it will be overwritten.
     fn register(
         &mut self,
         template: &Template,
-    ) -> Result<()> {
+    ) -> Result<(), Error> {
         self.0
             .register_template_string(&template.name, &template.s)
             .map_err(Error::HandlebarsTemplateError)
@@ -70,7 +70,7 @@ impl TemplateRegistry for TemplateHandlebarsRegistry {
     fn unregister<S>(
         &mut self,
         template_name: S,
-    ) -> Result<()>
+    ) -> Result<(), Error>
     where
         S: AsRef<str>,
     {
@@ -93,7 +93,7 @@ impl TemplateRegistry for TemplateHandlebarsRegistry {
         &self,
         template_name: S,
         value: V,
-    ) -> Result<String>
+    ) -> Result<String, Error>
     where
         S: AsRef<str>,
         V: serde::Serialize,
@@ -104,21 +104,21 @@ impl TemplateRegistry for TemplateHandlebarsRegistry {
     }
 }
 
-impl Deref for TemplateHandlebarsRegistry {
-    type Target = handlebars::Handlebars;
+impl<'a> Deref for TemplateHandlebarsRegistry<'a> {
+    type Target = handlebars::Handlebars<'a>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl AsMut<handlebars::Handlebars> for TemplateHandlebarsRegistry {
-    fn as_mut(&mut self) -> &mut handlebars::Handlebars {
+impl<'a> AsMut<handlebars::Handlebars<'a>> for TemplateHandlebarsRegistry<'a> {
+    fn as_mut(&mut self) -> &mut handlebars::Handlebars<'a> {
         &mut self.0
     }
 }
 
-impl TemplateHandlebarsRegistry {
+impl<'a> TemplateHandlebarsRegistry<'a> {
     /// Creates a new instance of the registry.
     pub fn new() -> Self {
         let mut renderer = handlebars::Handlebars::new();
@@ -134,22 +134,28 @@ impl TemplateHandlebarsRegistry {
 
     /// Register a vector of template.
     /// This does not check if the template registration is successful.
-    pub fn register_vec<'a>(
+    pub fn register_vec<'b>(
         &mut self,
-        templates: &'a Vec<Template>,
-    ) -> Result<Vec<&'a Template>> {
+        templates: &'b Vec<Template>,
+    ) -> Result<Vec<&'b Template>, Error> {
         let mut registered_templates = vec![];
+        let mut template_errors = vec![];
         for template in templates.iter() {
-            if self
+
+            match self
                 .0
                 .register_template_string(&template.name, &template.s)
-                .is_ok()
+                .map_err(Error::HandlebarsTemplateError)
             {
-                registered_templates.push(template);
+                Ok(_v) => registered_templates.push(template), 
+                Err(e) => template_errors.push(e),
             }
         }
 
-        Ok(registered_templates)
+        match template_errors.is_empty() {
+            true => Ok(registered_templates),
+            false => Err(template_errors).map_err(Error::Errors),
+        }
     }
 
     /// Register the template with the specified name.
@@ -158,7 +164,7 @@ impl TemplateHandlebarsRegistry {
         &mut self,
         name: N,
         s: S,
-    ) -> Result<()>
+    ) -> Result<(), Error>
     where
         N: AsRef<str>,
         S: AsRef<str>,
@@ -170,6 +176,7 @@ impl TemplateHandlebarsRegistry {
 }
 
 /// A generic struct for templates to be used in a template engine.
+#[derive(Debug)]
 pub struct Template {
     name: String,
     s: String,
@@ -186,7 +193,7 @@ impl Template {
     pub fn from_path<P, S>(
         path: P,
         name: S,
-    ) -> Result<Self>
+    ) -> Result<Self, Error>
     where
         P: AsRef<Path>,
         S: AsRef<str>,
@@ -211,7 +218,7 @@ impl TemplateGetter {
     pub fn get_templates<P, S>(
         path: P,
         file_ext: S,
-    ) -> Result<Vec<Template>>
+    ) -> Result<Vec<Template>, Error>
     where
         P: AsRef<Path>,
         S: AsRef<str>,
@@ -250,7 +257,7 @@ mod tests {
     use tempfile;
 
     #[test]
-    pub fn search_for_tex_files() -> Result<()> {
+    pub fn search_for_tex_files() -> Result<(), Error> {
         let tmp_dir = tempfile::TempDir::new().map_err(Error::IoError)?;
         for file in &["a.tex", "b.txt", "c.tex", "d.tex"] {
             let mut file_handle =

--- a/lib/src/templates.rs
+++ b/lib/src/templates.rs
@@ -1,5 +1,5 @@
 //! An adapter for a template engine.
-//! This is implemented in case Texture Notes decides to support multiple template engine.
+//! This is implemented in case Lanoma decides to support multiple template engine.
 //!
 //! (On the other hand, this may be just a case of overengineering.)
 

--- a/makefile
+++ b/makefile
@@ -12,7 +12,7 @@ clean:
 	cargo clean
 
 create-docs:
-	asciidoctor -b manpage -o texture-notes.1 docs/manual.adoc
+	asciidoctor -b manpage -o lanoma.1 docs/manual.adoc
 
 format:
 	cargo fmt

--- a/src/args.rs
+++ b/src/args.rs
@@ -2,8 +2,8 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
-#[structopt(name = "Texture Notes", about = "Manage your LaTeX study notes.")]
-pub struct TextureNotes {
+#[structopt(name = "Lanoma", about = "Manage your LaTeX study notes.")]
+pub struct Lanoma {
     #[structopt(
         short,
         long,

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -128,8 +128,6 @@ pub struct CompilationEnvironment {
     thread_count: i16,
 }
 
-
-
 impl Default for CompilationEnvironment {
     fn default() -> Self {
         Self {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -3,11 +3,11 @@ use std::path::{Path, PathBuf};
 use std::process;
 use std::str::FromStr;
 
+use lanoma_lib::error::Error;
+use lanoma_lib::masternote::MasterNote;
+use lanoma_lib::note::Note;
+use lanoma_lib::HANDLEBARS_REG;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
-use texture_notes_lib::error::Error;
-use texture_notes_lib::masternote::MasterNote;
-use texture_notes_lib::note::Note;
-use texture_notes_lib::HANDLEBARS_REG;
 use toml;
 
 use crate::helpers;
@@ -97,18 +97,6 @@ impl CompilationEnvironment {
         compilation_env
     }
 
-    /// Set the subject of the notes to be compiled.
-    pub fn path<S>(
-        &mut self,
-        path: S,
-    ) -> &mut Self
-    where
-        S: AsRef<Path>,
-    {
-        self.path = path.as_ref().to_path_buf();
-        self
-    }
-
     /// Set the notes to be compiled.
     pub fn compilables(
         &mut self,
@@ -121,11 +109,14 @@ impl CompilationEnvironment {
     }
 
     /// Set the command.
-    pub fn command(
+    pub fn command<S>(
         &mut self,
-        command: String,
-    ) -> &mut Self {
-        self.command = command;
+        command: S,
+    ) -> &mut Self
+    where
+        S: AsRef<str>,
+    {
+        self.command = command.as_ref().to_string();
         self
     }
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1,4 +1,6 @@
 use std::env;
+use std::fmt::{self, Debug, Display, Formatter};
+use std::iter::Sum;
 use std::path::{Path, PathBuf};
 use std::process;
 use std::str::FromStr;
@@ -11,6 +13,8 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use toml;
 
 use crate::helpers;
+
+pub type CompilableObject = Box<dyn Compilable>;
 
 /// A trait that converts an object into a command struct.
 pub trait Compilable: Send + Sync {
@@ -26,6 +30,24 @@ pub trait Compilable: Send + Sync {
         cmd: &str,
     ) -> Result<process::Output, Error> {
         self.to_command(&cmd).output().map_err(Error::IoError)
+    }
+}
+
+impl Display for dyn Compilable {
+    fn fmt(
+        &self,
+        f: &mut Formatter<'_>,
+    ) -> fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+impl Debug for dyn Compilable {
+    fn fmt(
+        &self,
+        f: &mut Formatter<'_>,
+    ) -> fmt::Result {
+        write!(f, "{:?}", self.name())
     }
 }
 
@@ -63,16 +85,50 @@ impl Compilable for Note {
     }
 }
 
+/// The result from the compilation process of the compenv.
+pub struct CompileResult {
+    pub path: PathBuf,
+    pub compiled: Vec<CompilableObject>,
+    pub failed: Vec<CompilableObject>,
+}
+
+impl Sum for CompileResult {
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = Self>,
+    {
+        iter.fold(Self::new(PathBuf::new()), |mut acc, mut object| {
+            acc.path = object.path;
+            acc.compiled.append(&mut object.compiled);
+            acc.failed.append(&mut object.failed);
+
+            acc
+        })
+    }
+}
+
+impl CompileResult {
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            compiled: Vec::new(),
+            failed: Vec::new(),
+        }
+    }
+}
+
 /// A struct for handling the parameters for the compilation environment.
 ///
 /// This data structure is made for abstracting the compilation process making it as a separate component.
 /// Ideally, this is used for compiling a subject and its notes/master note.
 pub struct CompilationEnvironment {
     pub path: PathBuf,
-    compilables: Vec<Box<dyn Compilable>>,
-    command: String,
+    pub compilables: Vec<CompilableObject>,
+    pub command: String,
     thread_count: i16,
 }
+
+
 
 impl Default for CompilationEnvironment {
     fn default() -> Self {
@@ -100,7 +156,7 @@ impl CompilationEnvironment {
     /// Set the notes to be compiled.
     pub fn compilables(
         &mut self,
-        notes: Vec<Box<dyn Compilable>>,
+        notes: Vec<CompilableObject>,
     ) -> &mut Self {
         // Reversing the note vector since the compilation process pops off the vector.
         self.compilables = notes;
@@ -131,18 +187,36 @@ impl CompilationEnvironment {
 
     /// Executes the compilation process.
     /// This also consume the struct.
-    pub fn compile(mut self) -> Result<Vec<Box<dyn Compilable>>, Error> {
+    pub fn compile(self) -> Result<CompileResult, Error> {
         let original_dir = env::current_dir().map_err(Error::IoError)?;
 
         env::set_current_dir(self.path.clone()).map_err(Error::IoError)?;
-        let command = self.command.clone();
-        let compiled_notes: Vec<Box<dyn Compilable>> = self
-            .compilables
+        let compilables = self.compilables;
+        let path = self.path;
+        let command = self.command;
+
+        let compile_result = compilables
             .into_par_iter()
-            .filter(|compilable| compilable.compile(&command).unwrap().status.success())
-            .collect();
+            .fold(
+                || CompileResult::new(path.clone()),
+                |mut result_struct, compilable| {
+                    match compilable.compile(&command) {
+                        Ok(output) => {
+                            if output.status.success() {
+                                result_struct.compiled.push(compilable);
+                            } else {
+                                result_struct.failed.push(compilable);
+                            }
+                        }
+                        Err(_e) => result_struct.failed.push(compilable),
+                    }
+
+                    result_struct
+                },
+            )
+            .sum();
         env::set_current_dir(original_dir).map_err(Error::IoError)?;
 
-        Ok(compiled_notes)
+        Ok(compile_result)
     }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,20 +1,20 @@
 use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::Write;
-use std::path::Path;
+use std::path::{self, Path, PathBuf};
 use std::process;
 
 use toml;
 
+use lanoma_lib::config::SubjectConfig;
 use lanoma_lib::error::Error;
 use lanoma_lib::masternote::MasterNote;
+use lanoma_lib::modify_toml_table;
 use lanoma_lib::note::Note;
 use lanoma_lib::profile::Profile;
 use lanoma_lib::shelf::{Shelf, ShelfData};
 use lanoma_lib::subjects::Subject;
 use lanoma_lib::Object;
-#[macro_use]
-use lanoma_lib::{modify_toml_table};
 
 pub fn master_note_full_object(
     profile: &Profile,
@@ -62,6 +62,23 @@ pub fn note_full_object(
     metadata
 }
 
+pub fn create_master_note_from_subject_str(
+    subject: &str,
+    shelf: &Shelf,
+) -> Result<MasterNote, Error> {
+    let subject = Subject::from_shelf(subject, &shelf)?;
+    let subject_config = subject.get_config(&shelf).unwrap_or(SubjectConfig::new());
+    let notes = subject.get_notes_in_fs(&subject_config.files, &shelf)?;
+
+    // Creating the master note instance and initializing the values.
+    let mut master_note = MasterNote::new(subject);
+    for note in notes {
+        master_note.push(&note);
+    }
+
+    Ok(master_note)
+}
+
 /// A generic function for writing a shelf item (as a file).
 pub fn write_file<P, S>(
     path: P,
@@ -101,4 +118,64 @@ where
     }
 
     command_process
+}
+
+/// Get the relative path from two paths similar to Python `os.path.relpath`.
+///
+/// This does not check whether the path exists in the filesystem.
+///
+/// Furthermore, this code is adapted from the [`pathdiff`](https://github.com/Manishearth/pathdiff/blob/master/src/lib.rs) crate
+/// which in turn adapted from the `rustc` code at
+/// https://github.com/rust-lang/rust/blob/e1d0de82cc40b666b88d4a6d2c9dcbc81d7ed27f/src/librustc_back/rpath.rs .
+pub fn relative_path_from<P: AsRef<Path>, Q: AsRef<Path>>(
+    dst: P,
+    base: Q,
+) -> Option<PathBuf> {
+    let base = base.as_ref();
+    let dst = dst.as_ref();
+
+    // checking if both of them are the same type of filepaths
+    if base.is_absolute() != dst.is_absolute() {
+        match dst.is_absolute() {
+            true => Some(PathBuf::from(dst)),
+            false => None,
+        }
+    } else {
+        let mut dst_components = dst.components();
+        let mut base_path_components = base.components();
+
+        let mut common_components: Vec<path::Component> = vec![];
+
+        // looping into each components
+        loop {
+            match (dst_components.next(), base_path_components.next()) {
+                // if both path are now empty
+                (None, None) => break,
+
+                // if the dst path has more components
+                (Some(c), None) => {
+                    common_components.push(c);
+                    common_components.extend(dst_components.by_ref());
+                    break;
+                }
+
+                // if the base path has more components
+                (None, _) => common_components.push(path::Component::ParentDir),
+                (Some(a), Some(b)) if common_components.is_empty() && a == b => (),
+                (Some(a), Some(b)) if b == path::Component::CurDir => common_components.push(a),
+                (Some(_), Some(b)) if b == path::Component::ParentDir => return None,
+                (Some(a), Some(_)) => {
+                    common_components.push(path::Component::ParentDir);
+                    for _ in base_path_components {
+                        common_components.push(path::Component::ParentDir);
+                    }
+                    common_components.push(a);
+                    common_components.extend(dst_components.by_ref());
+                    break;
+                }
+            }
+        }
+
+        Some(common_components.iter().map(|c| c.as_os_str()).collect())
+    }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,20 +1,20 @@
 use std::collections::HashMap;
-use std::fs::{self, OpenOptions};
+use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
 use std::process;
 
 use toml;
 
-use texture_notes_lib::error::Error;
-use texture_notes_lib::masternote::MasterNote;
-use texture_notes_lib::note::Note;
-use texture_notes_lib::profile::Profile;
-use texture_notes_lib::shelf::{Shelf, ShelfData};
-use texture_notes_lib::subjects::Subject;
-use texture_notes_lib::Object;
+use lanoma_lib::error::Error;
+use lanoma_lib::masternote::MasterNote;
+use lanoma_lib::note::Note;
+use lanoma_lib::profile::Profile;
+use lanoma_lib::shelf::{Shelf, ShelfData};
+use lanoma_lib::subjects::Subject;
+use lanoma_lib::Object;
 #[macro_use]
-use texture_notes_lib::{modify_toml_table, upsert_toml_table};
+use lanoma_lib::{modify_toml_table};
 
 pub fn master_note_full_object(
     profile: &Profile,


### PR DESCRIPTION
The config system has been reduced to a more naive and simpler system where the profile config and the subject config are entirely separate. 
This is to make the subject config more explicit and independent of the profile configs. 
Though, this type of system is still tentative and may have to be reworked (again) if I find it unsuitable and uncomfortable to use. 

Also, the error reporting has been slightly improved on the executable. 
(Though this should be a separate task.)

That, and the project has been renamed to 'Lanoma' since the current project name ('Texture Notes') is a bit hard to remember and type. 